### PR TITLE
Bugfix for ajaxSettings.beforeSend

### DIFF
--- a/jquery.cluetip.js
+++ b/jquery.cluetip.js
@@ -311,8 +311,8 @@
           var ajaxSettings = {
             cache: opts.ajaxCache, // force requested page not to be cached by browser
             url: tipAttribute,
-            beforeSend: function(xhr) {
-              if (optionBeforeSend) {optionBeforeSend.call(link, xhr, $cluetip, $cluetipInner);}
+            beforeSend: function(xhr, settings) {
+              if (optionBeforeSend) {optionBeforeSend.call(link, xhr, $cluetip, $cluetipInner, settings);}
               $cluetipOuter.children().empty();
               if (opts.waitImage) {
                 $cluetipWait


### PR DESCRIPTION
Fixed a bug where ajax settings were not being passed to the beforeSend call. 

Basic summary (I never submitted the bug):
   The $.ajax.beforeSend callback has 2 arguments, the xhr request and the xhr settings. The callback pass through in clue-tip was omitting the xhr settings from subsequent beforeSend callbacks (optionBeforeSend). I added the settings to the optionBeforeSend.call(..., settings) at the end for backwards compatibility.

I did not run a minimizer, as I didn't know what one you are using.
